### PR TITLE
Add support for detecting visible devices before initializing va-api

### DIFF
--- a/src/rocjpeg_vaapi_decoder.h
+++ b/src/rocjpeg_vaapi_decoder.h
@@ -70,6 +70,7 @@ private:
     RocJpegStatus InitVAAPI(std::string drm_node);
     RocJpegStatus CreateDecoderConfig();
     RocJpegStatus DestroyDataBuffers();
+    void GetVisibleDevices(std::vector<int>& visible_devices);
 };
 
 #endif // ROC_JPEG_VAAPI_DECODER_H_


### PR DESCRIPTION
This PR supports creating the correct DRM node during va-api initialization for rocJOEG if the HIP_VISIBLE_DEVICES is defined. This is similar to the change that we made for rocDecode. It also uses the correct gcn_arch_name_base (e.,g, using gfx942 instead of gfx942:sramecc+:xnack-).