### PR TITLE
Add support for adding a new struct RocJpegDecodeParams for passing the decode parameters to rocJpegDecode API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for rocJPEG is available at
 [https://rocm.docs.amd.com/projects/rocJPEG/en/latest/](TBD)
 
-## rocJPEG 0.2.0 (Unreleased)
+## rocJPEG 0.3.0 (Unreleased)
 
 ## Additions
 
@@ -18,6 +18,7 @@ Documentation for rocJPEG is available at
 * Dependencies - Updates to core dependencies
 * LibVA Headers - Use public headers
 * mesa-amdgpu-va-drivers - RPM Package available on RPM from ROCm 6.2
+* add the RocJpegDecodeParams struct for passing the decode parameters
 
 ### Fixes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@
 
 cmake_minimum_required (VERSION 3.5)
 
-set(VERSION "0.2.0")
+set(VERSION "0.3.0")
 set(CMAKE_CXX_STANDARD 17)
 
 # Set Project Version and Language

--- a/api/rocjpeg.h
+++ b/api/rocjpeg.h
@@ -118,6 +118,29 @@ typedef enum {
 } RocJpegOutputFormat;
 
 /*****************************************************/
+//! \struct RocJpegDecodeParams
+//! The RocJpegDecodeParams structure contains the decoding parameters that specify the RocJpegOutputFormat.
+//! It also defines the crop rectangle for the region of interest (ROI) and the target width and height for the decoded picture to be resized.
+//! Note that if both the crop rectangle and target dimensions are defined, cropping is done first, followed by resizing the resulting ROI to
+//! the target dimension.
+//! \ingroup group_amd_rocjpeg
+/*****************************************************/
+typedef struct {
+    RocJpegOutputFormat output_format; // Output data format. See RocJpegOutputFormat for description
+    struct {
+        int16_t left;
+        int16_t top;
+        int16_t right;
+        int16_t bottom;
+    } crop_rectangle; // (future use) Defines the region of interest (ROI) to be copied into the RocJpegImage output buffers.
+    struct {
+        uint32_t width;
+        uint32_t height;
+    } target_dimension; // (future use) Defines the target width and height of the picture to be resized. Both should be even.
+                        // if specified, allocate the RocJpegImage buffers based on these dimensions.
+} RocJpegDecodeParams;
+
+/*****************************************************/
 //! \enum RocJpegBackend
 //! \ingroup group_amd_rocjpeg
 //! RocJpegBackend enum specifies what type of backend to use for JPEG decoding
@@ -185,11 +208,11 @@ RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, const uint8_t
 //! IN handle : rocJpeg handle
 //! IN data : Pointer to the buffer containing the jpeg stream to be decoded.
 //! IN length : Length of the jpeg image buffer.
-//! IN output_format : Output data format. See RocJpegOutputFormat for description
+//! IN decode_params : Decode parameters. See RocJpegDecodeParams for description
 //! IN/OUT destination : Pointer to structure with information about output buffers. See RocJpegImage description.
 //! \return ROCJPEG_STATUS_SUCCESS if successful
 /*****************************************************************************************************/
-RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, const uint8_t *data, size_t length, RocJpegOutputFormat output_format, RocJpegImage *destination);
+RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, const uint8_t *data, size_t length, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
 /*****************************************************************************************************/
 //! \fn RocJpegStatus ROCJPEGAPI rocJpegDecodeBatchedInitialize(RocJpegHandle handle, int batch_size, int max_cpu_threads, RocJpegOutputFormat output_format);

--- a/docs/how-to/using-rocjpeg.rst
+++ b/docs/how-to/using-rocjpeg.rst
@@ -88,13 +88,14 @@ See the signature of this function below:
       RocJpegHandle handle,
       const uint8_t *data,
       size_t length,
-      RocJpegOutputFormat output_format,
+      const RocJpegDecodeParams *decode_params,
       RocJpegImage *destination);
 
-In the above ``rocJpegDecode()`` function, you can use the parameters ``RocJpegOutputFormat`` and ``RocJpegImage`` to set
+In the above ``rocJpegDecode()`` function, you can use the parameters ``RocJpegDecodeParams`` and ``RocJpegImage`` to set
 the output behavior of the ``rocJpegDecode()`` function. The ``RocJpegImage`` structure is JPEG image descriptor used to
 return the decoded output image. User must allocate device memories for each channel for this structure and pass it to the
-``rocJpegDecode()`` API. This API then copies the decoded image to this struct based on the requested output format ``RocJpegOutputFormat``.
+``rocJpegDecode()`` API. This API then copies the decoded image to this struct based on the requested output format ``RocJpegOutputFormat``
+defined in the ``RocJpegDecodeParams``.
 Below is the ``RocJpegImage`` structure.
 
 .. code:: cpp
@@ -104,7 +105,7 @@ Below is the ``RocJpegImage`` structure.
       uint32_t pitch[ROCJPEG_MAX_COMPONENT];
     } RocJpegImage;
 
-You can set the ``RocJpegOutputFormat`` parameter to one of the ``output_format`` settings below:
+You can set the ``RocJpegOutputFormat`` parameter of the ``RocJpegDecodeParams`` to one of the ``output_format`` settings below:
 
 .. csv-table::
   :header: "output_format", "Meaning"

--- a/samples/rocjpeg_samples_utils.h
+++ b/samples/rocjpeg_samples_utils.h
@@ -58,7 +58,7 @@ class RocJpegUtils {
 public:
     RocJpegUtils() {};
     static void ParseCommandLine(std::string &input_path, std::string &output_file_path, bool &save_images, int &device_id,
-                                 RocJpegBackend &rocjpeg_backend, RocJpegOutputFormat &output_format, int *num_threads, int argc, char *argv[]);
+                                 RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int argc, char *argv[]);
     static bool GetFilePaths(std::string &input_path, std::vector<std::string> &file_paths, bool &is_dir, bool &is_file);
     static bool InitHipDevice(int device_id);
     void GetChromaSubsamplingStr(RocJpegChromaSubsampling subsampling, std::string &chroma_sub_sampling);
@@ -86,7 +86,7 @@ void RocJpegUtils::ShowHelpAndExit(const char *option, bool show_threads) {
 }
 
 void RocJpegUtils::ParseCommandLine(std::string &input_path, std::string &output_file_path, bool &save_images, int &device_id,
-    RocJpegBackend &rocjpeg_backend, RocJpegOutputFormat &output_format, int *num_threads, int argc, char *argv[]) {
+    RocJpegBackend &rocjpeg_backend, RocJpegDecodeParams &decode_params, int *num_threads, int argc, char *argv[]) {
     if(argc <= 1) {
         ShowHelpAndExit("", num_threads != nullptr);
     }
@@ -129,15 +129,15 @@ void RocJpegUtils::ParseCommandLine(std::string &input_path, std::string &output
             }
             std::string selected_output_format = argv[i];
             if (selected_output_format == "native") {
-                output_format = ROCJPEG_OUTPUT_NATIVE;
+                decode_params.output_format = ROCJPEG_OUTPUT_NATIVE;
             } else if (selected_output_format == "yuv") {
-                output_format = ROCJPEG_OUTPUT_YUV_PLANAR;
+                decode_params.output_format = ROCJPEG_OUTPUT_YUV_PLANAR;
             } else if (selected_output_format == "y") {
-                output_format = ROCJPEG_OUTPUT_Y;
+                decode_params.output_format = ROCJPEG_OUTPUT_Y;
             } else if (selected_output_format == "rgb") {
-                output_format = ROCJPEG_OUTPUT_RGB;
+                decode_params.output_format = ROCJPEG_OUTPUT_RGB;
             } else if (selected_output_format == "rgb_planar") {
-                output_format = ROCJPEG_OUTPUT_RGB_PLANAR;
+                decode_params.output_format = ROCJPEG_OUTPUT_RGB_PLANAR;
             } else {
                 ShowHelpAndExit(argv[i], num_threads != nullptr);
             }

--- a/src/rocjpeg_api.cpp
+++ b/src/rocjpeg_api.cpp
@@ -80,7 +80,7 @@ RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, const uint8_t
 }
 
 /*****************************************************************************************************/
-//! \fn RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, const uint8_t *data, size_t length, RocJpegOutputFormat output_format, RocJpegImage *destination, hipStream_t stream);
+//! \fn RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, const uint8_t *data, size_t length, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 //! \ingroup group_amd_rocjpeg
 //! Decodes single image based on the backend used to create the rocJpeg handle in rocJpegCreate API.
 //! Destination buffers should be large enough to be able to store output of specified format. These buffers should be pre-allocted by the user in the device memories.
@@ -88,16 +88,16 @@ RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, const uint8_t
 //! and minimum required memory buffer for each plane is plane_height * plane_pitch where plane_pitch >= plane_width for
 //! planar output formats and plane_pitch >= plane_width * num_components for interleaved output format.
 /*****************************************************************************************************/
-RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, const uint8_t *data, size_t length, RocJpegOutputFormat output_format,
+RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, const uint8_t *data, size_t length, const RocJpegDecodeParams *decode_params,
     RocJpegImage *destination) {
 
-    if (handle == nullptr || data == nullptr) {
+    if (handle == nullptr || data == nullptr || decode_params == nullptr || destination == nullptr) {
         return ROCJPEG_STATUS_INVALID_PARAMETER;
     }
     RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
     auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
     try {
-        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->Decode(data, length, output_format, destination);
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->Decode(data, length, decode_params, destination);
     } catch (const std::exception& e) {
         rocjpeg_handle->CaptureError(e.what());
         ERR(e.what());

--- a/src/rocjpeg_decoder.h
+++ b/src/rocjpeg_decoder.h
@@ -39,7 +39,7 @@ class ROCJpegDecoder {
        ~ROCJpegDecoder();
        RocJpegStatus InitializeDecoder();
        RocJpegStatus GetImageInfo(const uint8_t *data, size_t length, uint8_t *num_components, RocJpegChromaSubsampling *subsampling, uint32_t *widths, uint32_t *heights);
-       RocJpegStatus Decode(const uint8_t *data, size_t length, RocJpegOutputFormat output_format, RocJpegImage *destination);
+       RocJpegStatus Decode(const uint8_t *data, size_t length, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
     private:
        RocJpegStatus InitHIP(int device_id);
        RocJpegStatus GetChromaHeight(uint32_t surface_format, uint16_t picture_height, uint16_t &chroma_height);


### PR DESCRIPTION
This PR introduces a new struct (RocJpegDecodeParams) for passing the decode parameters such as (output_format, crop rectangle, and target dimension). Both crop rectangle and target dimensions will be supported in the future PRs.