### PR TITLE
Optimize the memory pool allocation so that its size doesn't exceed the max_pool_size_

### DIFF
--- a/src/rocjpeg_vaapi_decoder.h
+++ b/src/rocjpeg_vaapi_decoder.h
@@ -198,6 +198,21 @@ class RocJpegVaapiMemoryPool {
         VADisplay va_display_; // The VADisplay associated with the memory pool.
         uint32_t max_pool_size_; // The maximum pool size of the memory pool (mem_pool_) per entry.
         std::unordered_map<uint32_t, std::vector<RocJpegVaapiMemPoolEntry>> mem_pool_; // The memory pool.
+        /**
+         * @brief Retrieves the total size of the memory pool.
+         *
+         * @return The total size of the memory pool in bytes.
+         */
+        size_t GetTotalMemPoolSize() const;
+        /**
+         * @brief  Deletes an idle entry from the memory pool.
+         *
+         * This function is responsible for removing an idle entry from the memory pool.
+         * It ensures that resources associated with the idle entry are properly released.
+         *
+         * @return true if the idle entry was successfully deleted, false otherwise.
+         */
+        bool DeleteIdleEntry();
 };
 
 /**


### PR DESCRIPTION
This PR ensures that the memory pool for vaapi surfaces, `mem_pool_`, does not exceed the `max_pool_size_` at any given time before adding a new entry. If the pool reaches its maximum size, an idle entry is deleted before adding a new item.