### PR TITLE
increase the mem_alignment size used for output image rgb memory allocation

### DIFF
--- a/samples/rocjpeg_samples_utils.h
+++ b/samples/rocjpeg_samples_utils.h
@@ -620,7 +620,7 @@ public:
     }
 
 private:
-    static const int mem_alignment = 1024 * 1024;
+    static const int mem_alignment = 4 * 1024 * 1024;
     /**
      * @brief Shows the help message and exits.
      *


### PR DESCRIPTION
This PR increases the memory alignment used for allocating output RGB images. It is a workaround to prevent segmentation faults caused by out-of-bounds access from HIP kernels used for color format conversion.