### PR TITLE
Create surfaces with linear modifier

### DIFF
--- a/src/rocjpeg_vaapi_decoder.h
+++ b/src/rocjpeg_vaapi_decoder.h
@@ -341,6 +341,7 @@ private:
     uint32_t min_picture_height_; // The minimum height of the picture
     uint32_t max_picture_width_; // The maximum width of the picture
     uint32_t max_picture_height_; // The maximum height of the picture
+    bool supports_modifiers_; // DRM format modifiers support
     VADisplay va_display_; // The VAAPI display
     VAContextID va_context_id_; // The VAAPI context ID
     std::vector<VAConfigAttrib> va_config_attrib_; // The VAAPI configuration attributes


### PR DESCRIPTION
Mesa will be enabling tiling for all VA surfaces by default, but HIP doesn't support modifiers for dmabuf import.