### PR TITLE
Increase the output image sizes

### DIFF
--- a/samples/rocjpeg_samples_utils.h
+++ b/samples/rocjpeg_samples_utils.h
@@ -332,29 +332,29 @@ public:
                     case ROCJPEG_CSS_444:
                         num_channels = 3;
                         output_image.pitch[2] = output_image.pitch[1] = output_image.pitch[0] = is_roi_valid ? roi_width : widths[0];
-                        channel_sizes[2] = channel_sizes[1] = channel_sizes[0] = output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]);
+                        channel_sizes[2] = channel_sizes[1] = channel_sizes[0] = align(output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]), mem_alignment);
                         break;
                     case ROCJPEG_CSS_440:
                         num_channels = 3;
                         output_image.pitch[2] = output_image.pitch[1] = output_image.pitch[0] = is_roi_valid ? roi_width : widths[0];
-                        channel_sizes[0] = output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]);
-                        channel_sizes[2] = channel_sizes[1] = output_image.pitch[0] * ((is_roi_valid ? roi_height : heights[0]) >> 1);
+                        channel_sizes[0] = align(output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]), mem_alignment);
+                        channel_sizes[2] = channel_sizes[1] = align(output_image.pitch[0] * ((is_roi_valid ? roi_height : heights[0]) >> 1), mem_alignment);
                         break;
                     case ROCJPEG_CSS_422:
                         num_channels = 1;
                         output_image.pitch[0] = (is_roi_valid ? roi_width : widths[0]) * 2;
-                        channel_sizes[0] = output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]);
+                        channel_sizes[0] = align(output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]), mem_alignment);
                         break;
                     case ROCJPEG_CSS_420:
                         num_channels = 2;
                         output_image.pitch[1] = output_image.pitch[0] = is_roi_valid ? roi_width : widths[0];
-                        channel_sizes[0] = output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]);
-                        channel_sizes[1] = output_image.pitch[1] * ((is_roi_valid ? roi_height : heights[0]) >> 1);
+                        channel_sizes[0] = align(output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]), mem_alignment);
+                        channel_sizes[1] = align(output_image.pitch[1] * ((is_roi_valid ? roi_height : heights[0]) >> 1), mem_alignment);
                         break;
                     case ROCJPEG_CSS_400:
                         num_channels = 1;
                         output_image.pitch[0] = is_roi_valid ? roi_width : widths[0];
-                        channel_sizes[0] = output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]);
+                        channel_sizes[0] = align(output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]), mem_alignment);
                         break;
                     default:
                         std::cout << "Unknown chroma subsampling!" << std::endl;
@@ -365,21 +365,21 @@ public:
                 if (subsampling == ROCJPEG_CSS_400) {
                     num_channels = 1;
                     output_image.pitch[0] = is_roi_valid ? roi_width : widths[0];
-                    channel_sizes[0] = output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]);
+                    channel_sizes[0] = align(output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]), mem_alignment);
                 } else {
                     num_channels = 3;
                     output_image.pitch[0] = is_roi_valid ? roi_width : widths[0];
                     output_image.pitch[1] = is_roi_valid ? roi_width : widths[1];
                     output_image.pitch[2] = is_roi_valid ? roi_width : widths[2];
-                    channel_sizes[0] = output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]);
-                    channel_sizes[1] = output_image.pitch[1] * (is_roi_valid ? roi_height : heights[1]);
-                    channel_sizes[2] = output_image.pitch[2] * (is_roi_valid ? roi_height : heights[2]);
+                    channel_sizes[0] = align(output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]), mem_alignment);
+                    channel_sizes[1] = align(output_image.pitch[1] * (is_roi_valid ? roi_height : heights[1]), mem_alignment);
+                    channel_sizes[2] = align(output_image.pitch[2] * (is_roi_valid ? roi_height : heights[2]), mem_alignment);
                 }
                 break;
             case ROCJPEG_OUTPUT_Y:
                 num_channels = 1;
                 output_image.pitch[0] = is_roi_valid ? roi_width : widths[0];
-                channel_sizes[0] = output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]);
+                channel_sizes[0] = align(output_image.pitch[0] * (is_roi_valid ? roi_height : heights[0]), mem_alignment);
                 break;
             case ROCJPEG_OUTPUT_RGB:
                 num_channels = 1;


### PR DESCRIPTION
Increase the output image sizes to avoid seg fault when using HIP kernels for post-processing.