### PR TITLE
code cleanup - remove unnecessary check

### DIFF
--- a/src/rocjpeg_vaapi_decoder.cpp
+++ b/src/rocjpeg_vaapi_decoder.cpp
@@ -383,12 +383,10 @@ RocJpegStatus RocJpegVappiDecoder::InitializeDecoder(std::string device_name, st
     GetGpuUuids();
 
     int offset = 0;
-    if (gcn_arch_name_base.compare("gfx942") == 0) {
-        std::vector<ComputePartition> current_compute_partitions;
-        GetCurrentComputePartition(current_compute_partitions);
-        if (!current_compute_partitions.empty()) {
-            GetDrmNodeOffset(device_name, device_id_, visible_devices, current_compute_partitions, offset);
-        }
+    std::vector<ComputePartition> current_compute_partitions;
+    GetCurrentComputePartition(current_compute_partitions);
+    if (!current_compute_partitions.empty()) {
+        GetDrmNodeOffset(device_name, device_id_, visible_devices, current_compute_partitions, offset);
     }
 
     std::string drm_node = "/dev/dri/renderD";


### PR DESCRIPTION
We are currently looking for a compute partition mode when the GCN architecture name is gfx942. However, this check is unnecessary because the function already verifies whether the path exists; if it does not, it simply returns nothing. Therefore, it is safe to remove this check. Eliminating it also prevents the need to add the GFX ID of the upcoming MI300 series to the code.