### PR TITLE
Fix few typos - no functional changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for rocJPEG is available at
 [https://rocm.docs.amd.com/projects/rocJPEG/en/latest/](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/)
 
-## (Unreleased) rocJPEG 0.7.0
+## (Unreleased) rocJPEG 0.8.0
 
 ### Changed
 

--- a/samples/jpegDecodePerf/README.md
+++ b/samples/jpegDecodePerf/README.md
@@ -1,4 +1,4 @@
-# JPEG decode multi-threads sample
+# JPEG decode perf sample
 
 The jpeg decode perf sample illustrates decoding JPEG images by batches of specified size with multiple threads using rocJPEG library to achieve optimal performance. The individual decoded images can be retrieved in one of the supported output format (i.e., native, yuv, y, rgb, rgb_planar). This sample can be configured with a device ID and optionally able to dump the output to a file.
 


### PR DESCRIPTION
The current version of rocJPEG is 0.8.0, which was not accurately reflected in the CHANGELOG.md. Additionally, the JPEG decode perf sample name was not updated correctly in the sample's README.