### PR TITLE
Code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for rocJPEG is available at
 [https://rocm.docs.amd.com/projects/rocJPEG/en/latest/](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/)
 
-## rocJPEG 0.11.1 for ROCm 6.5
+## rocJPEG 0.12.0 for ROCm 6.5
 
 ## Added
 * cmake config files

--- a/src/rocjpeg_vaapi_decoder.cpp
+++ b/src/rocjpeg_vaapi_decoder.cpp
@@ -849,26 +849,10 @@ RocJpegStatus RocJpegVappiDecoder::SubmitDecodeBatched(JpegStreamParameters *jpe
  * @return The status of the synchronization operation.
  */
 RocJpegStatus RocJpegVappiDecoder::SyncSurface(VASurfaceID surface_id) {
-    VASurfaceStatus surface_status;
     if (!vaapi_mem_pool_->FindSurfaceId(surface_id)) {
         return ROCJPEG_STATUS_INVALID_PARAMETER;
     }
-
-    CHECK_VAAPI(vaQuerySurfaceStatus(va_display_, surface_id, &surface_status));
-    while (surface_status != VASurfaceReady) {
-        VAStatus va_status = vaSyncSurface(va_display_, surface_id);
-        if (va_status != VA_STATUS_SUCCESS) {
-            if (va_status == 0x26 /*VA_STATUS_ERROR_TIMEDOUT*/) {
-                CHECK_VAAPI(vaQuerySurfaceStatus(va_display_, surface_id, &surface_status));
-            } else {
-                std::cout << "vaSyncSurface() failed with error code: 0x" << std::hex << va_status <<
-                    std::dec << "', status: " << vaErrorStr(va_status) << "' at " <<  __FILE__ << ":" << __LINE__ << std::endl;
-                return ROCJPEG_STATUS_RUNTIME_ERROR;
-            }
-        } else {
-            break;
-        }
-    }
+    CHECK_VAAPI(vaSyncSurface(va_display_, surface_id));
     return ROCJPEG_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
This PR eliminates the call to `vaQuerySurfaceStatus`, which is unnecessary. According to the VA-API specification, we must explicitly call `vaSyncSurface` to ensure that any pending operations on a surface are complete and that the surface is ready.