### PR TITLE
CMake - update the rocjpeg version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 # rocJPEG Version
 # NOTE: package version and rocjpeg_version.h is generated with this version
-set(VERSION "0.11.2")
+set(VERSION "0.12.0")
 
 # Set Project Version and Language
 project(rocjpeg VERSION ${VERSION} LANGUAGES CXX)


### PR DESCRIPTION
The rocjpeg version was not updated in PR #149, so it is being updated here.