### PR TITLE
Fix a bug caused by the reuse of the surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for rocJPEG is available at
 [https://rocm.docs.amd.com/projects/rocJPEG/en/latest/](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/)
 
-## rocJPEG 0.14.0 (unreleased)
+## rocJPEG 0.14.1 (unreleased)
 
 ## Added
 * cmake config files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 # rocJPEG Version
 # NOTE: package version and rocjpeg_version.h is generated with this version
-set(VERSION "0.14.0")
+set(VERSION "0.14.1")
 
 # Set Project Version and Language
 project(rocjpeg VERSION ${VERSION} LANGUAGES CXX)

--- a/src/rocjpeg_decoder.cpp
+++ b/src/rocjpeg_decoder.cpp
@@ -286,12 +286,14 @@ RocJpegStatus RocJpegDecoder::DecodeBatched(RocJpegStreamHandle *jpeg_streams, i
                 default:
                     break;
             }
+        }
+        CHECK_HIP(hipStreamSynchronize(hip_stream_));
+        for (int k = 0; k < current_batch_size; k++) {
+            VASurfaceID current_surface_id = *(current_surface_ids.data() + k + i);
             CHECK_ROCJPEG(jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_id));
         }
-
     }
 
-    CHECK_HIP(hipStreamSynchronize(hip_stream_));
     return ROCJPEG_STATUS_SUCCESS;
 }
 /**


### PR DESCRIPTION
This PR addresses a regression that was introduced by PR #159, which involved the reuse of surfaces during decoding. The solution is to invoke `hipStreamSynchronize` to ensure that the data transfer from the HIP interop buffer to the destination buffers is completed before the surfaces are marked as idle. This prevents any risk of overwriting the surfaces.