### PR TITLE
updated wording around supported linux environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ rocJPEG is a high performance JPEG decode SDK for AMD GPUs. Using the rocJPEG AP
 * Linux
   * Ubuntu - `22.04` / `24.04`
   * RedHat - `8` / `9`
-  * SLES - `15-SP5`
+  * SLES - `15 SP6` / `15 SP7`
 
 ### Hardware
 * **GPU**: [AMD Radeon&trade; Graphics](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html) / [AMD Instinct&trade; Accelerators](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html)

--- a/docs/install/rocjpeg-prerequisites.rst
+++ b/docs/install/rocjpeg-prerequisites.rst
@@ -14,6 +14,7 @@ rocJPEG has been tested on the following Linux environments:
   
 * Ubuntu 22.04 and 24.04
 * RHEL 8 and 9
+* SLES 15 SP6 and SP7
 
 See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 

--- a/docs/install/rocjpeg-prerequisites.rst
+++ b/docs/install/rocjpeg-prerequisites.rst
@@ -12,9 +12,10 @@ ROCm 6.3.0 or later must be installed before installing rocJPEG. See `Quick star
 
 rocJPEG has been tested on the following Linux environments:
   
-* Ubuntu 22.04 or 24.04
-* RHEL 8 or 9
+* Ubuntu 22.04 and 24.04
+* RHEL 8 and 9
 * SLES: 15-SP5
+
 
 See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 

--- a/docs/install/rocjpeg-prerequisites.rst
+++ b/docs/install/rocjpeg-prerequisites.rst
@@ -14,8 +14,6 @@ rocJPEG has been tested on the following Linux environments:
   
 * Ubuntu 22.04 and 24.04
 * RHEL 8 and 9
-* SLES: 15-SP5
-
 
 See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 
@@ -26,3 +24,4 @@ The following prerequisites are installed by the package installer. If you are b
 * Video Acceleration API (VA-API) - libva-amdgpu-dev is an AMD implementation for VA-API
 * AMD VA Drivers
 * libstdc++-12-dev for installations on Ubuntu 22.04 
+

--- a/docs/install/rocjpeg-prerequisites.rst
+++ b/docs/install/rocjpeg-prerequisites.rst
@@ -10,11 +10,13 @@ rocJPEG requires ROCm 6.3 or later running on `accelerators based on the CDNA ar
 
 ROCm 6.3.0 or later must be installed before installing rocJPEG. See `Quick start installation guide <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html>`_ for detailed ROCm installation instructions.
 
-rocJPEG can be installed on the following Linux environments:
+rocJPEG has been tested on the following Linux environments:
   
 * Ubuntu 22.04 or 24.04
 * RHEL 8 or 9
 * SLES: 15-SP5
+
+See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 
 The following prerequisites are installed by the package installer. If you are building and installing using the source code, use the `rocJPEG-setup.py <https://github.com/ROCm/rocJPEG/blob/develop/rocJPEG-setup.py>`_ setup script available in the rocJPEG GitHub repository to install these prerequisites. 
 


### PR DESCRIPTION
## Motivation

Need to make clear that rocJPEG has only been tested on a subset of Linux environments.