### PR TITLE
Fix a memory leak in the jpegdecode app

### DIFF
--- a/samples/jpegDecode/jpegdecode.cpp
+++ b/samples/jpegDecode/jpegdecode.cpp
@@ -191,7 +191,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    for (int i = 0; i < num_channels; i++) {
+    for (int i = 0; i < ROCJPEG_MAX_COMPONENT; i++) {
         if (output_image.channel[i] != nullptr) {
             CHECK_HIP(hipFree((void *)output_image.channel[i]));
             output_image.channel[i] = nullptr;


### PR DESCRIPTION
## Motivation

Resolve a memory leak in the jpegDecode application.

## Technical Details

The HIP memory clean-up was absent for some channels in the output image.

## Test Plan

Run the jpegdecode application.

## Test Result

The test should pass without any failures.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
