### PR TITLE
removing SP6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ rocJPEG is a high performance JPEG decode SDK for AMD GPUs. Using the rocJPEG AP
 * Linux
   * Ubuntu - `22.04` / `24.04`
   * RedHat - `8` / `9`
-  * SLES - `15 SP6` / `15 SP7`
+  * SLES - `15 SP7`
 
 ### Hardware
 * **GPU**: [AMD Radeon&trade; Graphics](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html) / [AMD Instinct&trade; Accelerators](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html)

--- a/docs/install/rocjpeg-prerequisites.rst
+++ b/docs/install/rocjpeg-prerequisites.rst
@@ -14,7 +14,7 @@ rocJPEG has been tested on the following Linux environments:
   
 * Ubuntu 22.04 and 24.04
 * RHEL 8 and 9
-* SLES 15 SP6 and SP7
+* SLES 15 SP7
 
 See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 


### PR DESCRIPTION
## Motivation

SLES 15 SP6 is not supported in rocm 7.0