### PR TITLE
Update rocJPEG package dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,19 +345,19 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   string(REGEX MATCH "22.04" UBUNTU_22_FOUND ${OS_RELEASE})
 
   # Set the dependent packages
-  set(rocJPEG_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, libva2-amdgpu, libva-amdgpu-drm2, libva-amdgpu-wayland2, libva-amdgpu-x11-2, mesa-amdgpu-va-drivers")
-  set(rocJPEG_RPM_PACKAGE_LIST     "rocm-hip-runtime, (libva >= 2.16.0 or libva2 >= 2.16.0 or libva-amdgpu), mesa-amdgpu-va-drivers")
+  set(rocJPEG_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, libva-drm2 (>= 2.16.0) | libva-amdgpu-drm2, mesa-amdgpu-va-drivers")
+  set(rocJPEG_RPM_PACKAGE_LIST     "rocm-hip-runtime, (libva >= 2.16.0 or libva-drm2 >= 2.16.0 or libva-amdgpu), mesa-amdgpu-va-drivers")
   # Add rocprofiler-register dependencies
   if(ROCJPEG_ENABLE_ROCPROFILER_REGISTER)
     set(rocJPEG_DEBIAN_PACKAGE_LIST "${rocJPEG_DEBIAN_PACKAGE_LIST}, rocprofiler-register")
     set(rocJPEG_RPM_PACKAGE_LIST "${rocJPEG_RPM_PACKAGE_LIST}, rocprofiler-register")
   endif()
 
-  set(rocJPEG_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-amdgpu-dev")
+  set(rocJPEG_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-dev (>= 2.16.0) | libva-amdgpu-dev")
   if(UBUNTU_22_FOUND)
     set(rocJPEG_DEBIAN_DEV_PACKAGE_LIST "${rocJPEG_DEBIAN_DEV_PACKAGE_LIST}, libstdc++-12-dev")
   endif()
-  set(rocJPEG_RPM_DEV_PACKAGE_LIST  "rocm-hip-runtime-devel, libva-amdgpu-devel")
+  set(rocJPEG_RPM_DEV_PACKAGE_LIST  "rocm-hip-runtime-devel, (libva-devel >= 2.16.0 or libva-amdgpu-devel)")
 
   # '%{?dist}' breaks manual builds on debian systems due to empty Provides
   execute_process(
@@ -477,7 +477,7 @@ else()
     message(FATAL_ERROR "-- ERROR!: HIP Not Found! - please install rocm-hip-runtime-dev!")
   endif()
   if(NOT Libva_FOUND)
-    message(FATAL_ERROR "-- ERROR!: libva Not Found - please install libva-amdgpu-dev(DEBIAN)/libva-amdgpu-devel(RPM) package!")
+    message(FATAL_ERROR "-- ERROR!: libva Not Found - please install (libva-dev >= 2.16 or libva-amdgpu-dev(DEBIAN))/(libva-devel >= 2.16 or libva-amdgpu-devel(RPM)) package!")
   endif()
   if(NOT Libdrm_amdgpu_FOUND)
     message(FATAL_ERROR "-- ERROR!: libdrm_amdgpu Not Found - please install libdrm-amdgpu-dev(DEBIAN)/libdrm-amdgpu-devel(RPM) package!")

--- a/cmake/FindLibva.cmake
+++ b/cmake/FindLibva.cmake
@@ -23,7 +23,7 @@
 
 find_library(LIBVA_LIBRARY NAMES va HINTS /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 /usr/lib/x86_64-linux-gnu /usr/lib64)
 find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 /usr/lib/x86_64-linux-gnu /usr/lib64)
-find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS /opt/amdgpu/include NO_DEFAULT_PATH)
+find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS /opt/amdgpu/include /usr/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Libva DEFAULT_MSG LIBVA_INCLUDE_DIR LIBVA_LIBRARY)

--- a/rocJPEG-setup.py
+++ b/rocJPEG-setup.py
@@ -159,32 +159,57 @@ commonPackages = [
 
 # Debian packages
 coreDebianPackages = [
-    'rocm-hip-runtime-dev',
-    'libva-amdgpu-dev'
+    'libva-dev',
+    'rocm-hip-runtime-dev'
 ]
 coreDebianU22Packages = [
+    'libva-amdgpu-dev',
+    'rocm-hip-runtime-dev',
     'libstdc++-12-dev'
 ]
 runtimeDebianPackages = [
-    'libva2-amdgpu',
+    'libva-drm2',
+    'mesa-amdgpu-va-drivers',
+    'vainfo'
+]
+runtimeDebianU22Packages = [
     'libva-amdgpu-drm2',
-    'libva-amdgpu-wayland2',
-    'libva-amdgpu-x11-2',
     'mesa-amdgpu-va-drivers',
     'vainfo'
 ]
 
 # RPM Packages
-coreRPMPackages = [
-    'rocm-hip-runtime-devel',
-    'libva-amdgpu-devel'
-]
-
-runtimeRPMPackages = [
-    'libva-amdgpu',
-    'mesa-amdgpu-va-drivers',
-    'libva-utils'
-]
+if "centos" in os_info_data or "redhat" in os_info_data:
+    if "VERSION_ID=7" in os_info_data or "VERSION_ID=8" in os_info_data:
+        coreRPMPackages = [
+            'libva-amdgpu-devel',
+            'rocm-hip-runtime-devel'
+        ]
+        runtimeRPMPackages = [
+            'libva-amdgpu',
+            'mesa-amdgpu-va-drivers',
+            'libva-utils'
+        ]
+    else:
+        coreRPMPackages = [
+            'libva-devel',
+            'rocm-hip-runtime-devel'
+        ]
+        runtimeRPMPackages = [
+            'libva',
+            'mesa-amdgpu-va-drivers',
+            'libva-utils'
+        ]
+else:
+    coreRPMPackages = [
+        'libva-devel',
+        'rocm-hip-runtime-devel'
+    ]
+    runtimeRPMPackages = [
+        'libva-drm2',
+        'mesa-amdgpu-va-drivers',
+        'libva-utils'
+    ]
 
 # update
 ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +' '+linuxSystemInstall_check+' '+osUpdate))
@@ -198,13 +223,14 @@ for i in range(len(commonPackages)):
 # rocJPEG Core - Requirements
 ERROR_CHECK(os.system('sudo '+sudoValidateOption))
 if "Ubuntu" in platfromInfo:
-    for i in range(len(coreDebianPackages)):
-        ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
-                ' '+linuxSystemInstall_check+' install '+ coreDebianPackages[i]))
     if "VERSION_ID=22" in os_info_data:
         for i in range(len(coreDebianU22Packages)):
             ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
                     ' '+linuxSystemInstall_check+' install '+ coreDebianU22Packages[i]))
+    else:
+        for i in range(len(coreDebianPackages)):
+            ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
+                    ' '+linuxSystemInstall_check+' install '+ coreDebianPackages[i]))
 else:
     for i in range(len(coreRPMPackages)):
         ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
@@ -214,9 +240,14 @@ else:
 ERROR_CHECK(os.system('sudo '+sudoValidateOption))
 if runtimeInstall == 'ON':
     if "Ubuntu" in platfromInfo:
-        for i in range(len(runtimeDebianPackages)):
-            ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
-                ' '+linuxSystemInstall_check+' install '+ runtimeDebianPackages[i]))
+        if "VERSION_ID=22" in os_info_data:
+            for i in range(len(runtimeDebianU22Packages)):
+                ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
+                    ' '+linuxSystemInstall_check+' install '+ runtimeDebianU22Packages[i]))
+        else:
+            for i in range(len(runtimeDebianPackages)):
+                ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
+                    ' '+linuxSystemInstall_check+' install '+ runtimeDebianPackages[i]))
     else:
         for i in range(len(runtimeRPMPackages)):
             ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +


### PR DESCRIPTION
## Motivation

Update rocJPEG package dependencies to permit libva public if the version is >= 2.16.

## Technical Details

This PR updates the rocJPEG package dependencies to allow using libva public if the version is >= 2.16.

## Test Plan

run rocJPEG CTEST

## Test Result

rocJPEG CTEST should pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
