### PR TITLE
CMake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,11 +258,7 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
               message(STATUS "ROCm version is below the required threshold (>= 7.0.0) for reusing the interop buffer, so the compile option: ENABLE_INTEROP_BUFFER_REUSE is disabled.")
               target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_INTEROP_BUFFER_REUSE=0)
           endif()
-      else()
-          message(WARNING "Failed to parse ROCm version string: ${ROCM_VERSION_STRING}")
       endif()
-  else()
-    message(WARNING "ROCm version file not found at ${ROCM_VERSION_FILE}")
   endif()
 
   #Generate BUILD_INFO


### PR DESCRIPTION
## Motivation

Addresses issue #196 

## Technical Details

Removes unnecessary CMake Warning.

## Test Plan

Run cmake with TheRock

## Test Result

There shouldn't be any CMake warnings.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
