### PR TITLE
Drop libva-amdgpu/libva-amdgpu-devel use of RHEL8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,7 +373,7 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
 
   # Set the dependent packages
   set(rocJPEG_DEBIAN_PACKAGE_LIST  "hip-runtime-amd, libva-drm2 (>= 2.16.0) | libva-amdgpu-drm2, mesa-amdgpu-va-drivers")
-  set(rocJPEG_RPM_PACKAGE_LIST     "hip-runtime-amd, (libva >= 2.16.0 or libva-drm2 >= 2.16.0 or libva-amdgpu), mesa-amdgpu-va-drivers")
+  set(rocJPEG_RPM_PACKAGE_LIST     "hip-runtime-amd, (libva or libva-drm2), mesa-amdgpu-va-drivers")
   # Add rocprofiler-register dependencies
   if(ROCJPEG_ENABLE_ROCPROFILER_REGISTER)
     set(rocJPEG_DEBIAN_PACKAGE_LIST "${rocJPEG_DEBIAN_PACKAGE_LIST}, rocprofiler-register")
@@ -384,7 +384,7 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   if(UBUNTU_22_FOUND)
     set(rocJPEG_DEBIAN_DEV_PACKAGE_LIST "${rocJPEG_DEBIAN_DEV_PACKAGE_LIST}, libstdc++-12-dev")
   endif()
-  set(rocJPEG_RPM_DEV_PACKAGE_LIST  "hip-devel, (libva-devel >= 2.16.0 or libva-amdgpu-devel)")
+  set(rocJPEG_RPM_DEV_PACKAGE_LIST  "hip-devel, libva-devel")
 
   # '%{?dist}' breaks manual builds on debian systems due to empty Provides
   execute_process(

--- a/rocJPEG-setup.py
+++ b/rocJPEG-setup.py
@@ -180,26 +180,15 @@ runtimeDebianU22Packages = [
 
 # RPM Packages
 if "centos" in os_info_data or "redhat" in os_info_data:
-    if "VERSION_ID=7" in os_info_data or "VERSION_ID=8" in os_info_data:
-        coreRPMPackages = [
-            'libva-amdgpu-devel',
-            'hip-devel'
-        ]
-        runtimeRPMPackages = [
-            'libva-amdgpu',
-            'mesa-amdgpu-va-drivers',
-            'libva-utils'
-        ]
-    else:
-        coreRPMPackages = [
-            'libva-devel',
-            'hip-devel'
-        ]
-        runtimeRPMPackages = [
-            'libva',
-            'mesa-amdgpu-va-drivers',
-            'libva-utils'
-        ]
+    coreRPMPackages = [
+        'libva-devel',
+        'hip-devel'
+    ]
+    runtimeRPMPackages = [
+        'libva',
+        'mesa-amdgpu-va-drivers',
+        'libva-utils'
+    ]
 else:
     coreRPMPackages = [
         'libva-devel',


### PR DESCRIPTION
## Motivation

Drop libva-amdgpu/libva-amdgpu-devel use of RHEL8

## Technical Details

libva-amdgpu/libva-amdgpu-devel have been discontined on RHEL8. We can use libva/libva-devel.

## Test Plan

rocJPEG CTEST

## Test Result

CTEST should pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
