### PR TITLE
Add Support for TheRock compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 Documentation for rocJPEG is available at
 [https://rocm.docs.amd.com/projects/rocJPEG/en/latest/](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/)
 
-
 ## rocJPEG 1.3.0 for ROCm 7.2.0
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 Documentation for rocJPEG is available at
 [https://rocm.docs.amd.com/projects/rocJPEG/en/latest/](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/)
 
-## (Unreleased) rocJPEG 1.4.0
-* Added TheRock compatibility
 
 ## rocJPEG 1.3.0 for ROCm 7.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Documentation for rocJPEG is available at
 [https://rocm.docs.amd.com/projects/rocJPEG/en/latest/](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/)
 
+## (Unreleased) rocJPEG 1.4.0
+* Added TheRock compatibility
+
 ## rocJPEG 1.3.0 for ROCm 7.2.0
 
 ## Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,10 @@ if(NOT DEFINED CMAKE_CXX_COMPILER)
   set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/amdclang++)
 endif()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --rocm-path=${ROCM_PATH} --rocm-device-lib-path=${ROCM_PATH}/lib/llvm/amdgcn/bitcode")
 # rocjpeg Version
 # NOTE: package version and rocjpeg_version.h is generated with this version
-set(VERSION "1.3.0")
+set(VERSION "1.4.0")
 
 # Set Project Version and Language
 project(rocjpeg VERSION ${VERSION} LANGUAGES CXX)
@@ -133,6 +134,7 @@ message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourRe
 # Add an option for enabling the rocprofiler-register
 option(ROCJPEG_ENABLE_ROCPROFILER_REGISTER "Enable rocprofiler-register support" ON)
 
+set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(Libva QUIET)
 find_package(Libdrm_amdgpu QUIET)
@@ -221,6 +223,10 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
   set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
   set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+
+  if(USING_THE_ROCK)
+    set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN;$ORIGIN/rocm_sysdeps/lib" BUILD_WITH_INSTALL_RPATH TRUE)
+  endif()
 
   # rocprofiler
   if(rocprofiler-register_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ if(NOT DEFINED CMAKE_CXX_COMPILER)
   set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/amdclang++)
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --rocm-path=${ROCM_PATH} --rocm-device-lib-path=${ROCM_PATH}/lib/llvm/amdgcn/bitcode")
 # rocjpeg Version
 # NOTE: package version and rocjpeg_version.h is generated with this version
 set(VERSION "1.4.0")

--- a/samples/jpegDecode/CMakeLists.txt
+++ b/samples/jpegDecode/CMakeLists.txt
@@ -44,6 +44,7 @@ project(jpegdecode)
 
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
 
+set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocjpeg QUIET)
 find_package(rocprofiler-register QUIET)

--- a/samples/jpegDecodeBatched/CMakeLists.txt
+++ b/samples/jpegDecodeBatched/CMakeLists.txt
@@ -44,6 +44,7 @@ project(jpegdecodebatched)
 
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
 
+set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocjpeg QUIET)
 find_package(rocprofiler-register QUIET)

--- a/samples/jpegDecodePerf/CMakeLists.txt
+++ b/samples/jpegDecodePerf/CMakeLists.txt
@@ -44,6 +44,7 @@ project(jpegdecodeperf)
 
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
 
+set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocjpeg QUIET)
 find_package(rocprofiler-register QUIET)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -78,6 +78,12 @@ else()
   endif(rocjpeg_FOUND)
 endif(BUILD_FROM_SOURCE)
 
+# Check if lib/rocm_sysdeps/lib exists in the ROCm path which indicates ROCm installation via TheRock
+set(USING_THE_ROCK OFF)
+if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+  set(USING_THE_ROCK ON)
+endif()
+
 add_test(
   NAME
     jpeg-decode-fmt-native
@@ -89,6 +95,9 @@ add_test(
             --test-command "jpegdecode"
             -i ${ROCM_PATH}/share/rocjpeg/images/
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-fmt-native PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -101,6 +110,9 @@ add_test(
             --test-command "jpegdecode"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt yuv_planar
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-fmt-yuv-planar PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -113,6 +125,9 @@ add_test(
             --test-command "jpegdecode"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt y
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-fmt-y PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -125,6 +140,9 @@ add_test(
             --test-command "jpegdecode"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt rgb
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-fmt-rgb PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -137,6 +155,9 @@ add_test(
             --test-command "jpegdecode"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt rgb_planar
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-fmt-rgb-planar PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -149,6 +170,9 @@ add_test(
             --test-command "jpegdecode"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -crop 960,540,2880,1620
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-crop-fmt-native PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -161,6 +185,9 @@ add_test(
             --test-command "jpegdecode"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt yuv_planar -crop 960,540,2880,1620
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-crop-fmt-yuv-planar PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -173,6 +200,9 @@ add_test(
             --test-command "jpegdecode"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt y -crop 960,540,2880,1620
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-crop-fmt-y PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -185,6 +215,9 @@ add_test(
             --test-command "jpegdecode"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt rgb -crop 960,540,2880,1620
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-crop-fmt-rgb PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -197,6 +230,9 @@ add_test(
             --test-command "jpegdecode"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt rgb_planar -crop 960,540,2880,1620
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-crop-fmt-rgb-planar PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -209,6 +245,9 @@ add_test(
             --test-command "jpegdecodebatched"
             -i ${ROCM_PATH}/share/rocjpeg/images/
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-batch-fmt-native PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -221,6 +260,9 @@ add_test(
             --test-command "jpegdecodebatched"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt yuv_planar
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-batch-fmt-yuv-planar PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -233,6 +275,9 @@ add_test(
             --test-command "jpegdecodebatched"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt y
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-batch-fmt-y PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -245,6 +290,9 @@ add_test(
             --test-command "jpegdecodebatched"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt rgb
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-batch-fmt-rgb PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -257,6 +305,9 @@ add_test(
             --test-command "jpegdecodebatched"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt rgb_planar
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-batch-fmt-rgb-planar PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -269,6 +320,9 @@ add_test(
             --test-command "jpegdecodebatched"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -crop 960,540,2880,1620
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-batch-crop-fmt-native PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -281,6 +335,9 @@ add_test(
             --test-command "jpegdecodebatched"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt yuv_planar -crop 960,540,2880,1620
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-batch-crop-fmt-yuv-planar PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -293,6 +350,9 @@ add_test(
             --test-command "jpegdecodebatched"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt y -crop 960,540,2880,1620
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-batch-crop-fmt-y PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -305,6 +365,9 @@ add_test(
             --test-command "jpegdecodebatched"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt rgb -crop 960,540,2880,1620
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-batch-crop-fmt-rgb PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -317,6 +380,9 @@ add_test(
             --test-command "jpegdecodebatched"
             -i ${ROCM_PATH}/share/rocjpeg/images/ -fmt rgb_planar -crop 960,540,2880,1620
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-batch-crop-fmt-rgb-planar PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -329,6 +395,9 @@ add_test(
             --test-command "jpegdecodeperf"
             -i ${ROCM_PATH}/share/rocjpeg/images/
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-decode-perf-fmt-native PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()
 
 add_test(
   NAME
@@ -340,3 +409,6 @@ add_test(
             --build-generator "${CMAKE_GENERATOR}"
             --test-command "rocjpegnegativetest"
 )
+if(USING_THE_ROCK)
+  set_property(TEST jpeg-negative-api-tests PROPERTY ENVIRONMENT "LIBVA_DRIVERS_PATH=${ROCM_PATH}/lib/rocm_sysdeps/lib")
+endif()

--- a/test/rocjpeg_negative_api_tests/CMakeLists.txt
+++ b/test/rocjpeg_negative_api_tests/CMakeLists.txt
@@ -61,6 +61,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
 
+set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocjpeg QUIET)
 find_package(rocprofiler-register QUIET)


### PR DESCRIPTION
## Motivation

Add support for TheRock compatibility

## Technical Details

This PR adds support for TheRock compatibility so that we can build and run tests just by specifying the ROCM_PATH. It addresses issue #212 

## Test Plan

rocJPEG CTEST

## Test Result

rocJPEG CTEST should pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
