### PR TITLE
Add a check to detect JPEG images that contain an unsupported number of components for VCN

### DIFF
--- a/src/rocjpeg_parser.cpp
+++ b/src/rocjpeg_parser.cpp
@@ -330,7 +330,7 @@ bool RocJpegStreamParser::ParseSOS() {
 
     uint32_t num_components = stream_[2];
 
-    if (num_components > NUM_COMPONENTS - 1) {
+    if (num_components > NUM_COMPONENTS - 1 || num_components != jpeg_stream_parameters_.picture_parameter_buffer.num_components) {
         ERR("invalid number of component!")
         return false;
     }


### PR DESCRIPTION

## Motivation

Add a check to detect JPEG images that contain an unsupported number of components for VCN

## Technical Details

 The number of components in SOS and SOF markers must match; otherwise, the VCN cannot decode the JPEG.

## Test Plan

rocJPEG CTEST

## Test Result

rocJPEG CTEST must pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
