### PR TITLE
Update the Copyright year

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 - 2025 ROCm Software Platform 
+Copyright (c) 2024 - 2026 ROCm Software Platform
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/api/amd_detail/rocjpeg_api_trace.h
+++ b/api/amd_detail/rocjpeg_api_trace.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/api/rocjpeg/rocjpeg.h
+++ b/api/rocjpeg/rocjpeg.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+/* Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/api/rocjpeg_version.h.in
+++ b/api/rocjpeg_version.h.in
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cmake/FindLibdrm_amdgpu.cmake
+++ b/cmake/FindLibdrm_amdgpu.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/cmake/FindLibva.cmake
+++ b/cmake/FindLibva.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ left_nav_title = f"rocJPEG {version_number} Documentation"
 # for PDF output on Read the Docs
 project = "rocJPEG Documentation"
 author = "Advanced Micro Devices, Inc."
-copyright = "Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved."
+copyright = "Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved."
 version = version_number
 release = version_number
 

--- a/rocJPEG-setup.py
+++ b/rocJPEG-setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,7 @@ if sys.version_info[0] < 3:
 else:
     import subprocess
 
-__copyright__ = "Copyright (c) 2024 - 2025, AMD ROCm rocJPEG"
+__copyright__ = "Copyright (c) 2024 - 2026, AMD ROCm rocJPEG"
 __version__ = "2.4.0"
 __email__ = "mivisionx.support@amd.com"
 __status__ = "Shipping"

--- a/samples/jpegDecode/CMakeLists.txt
+++ b/samples/jpegDecode/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/samples/jpegDecode/jpegdecode.cpp
+++ b/samples/jpegDecode/jpegdecode.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/samples/jpegDecodeBatched/CMakeLists.txt
+++ b/samples/jpegDecodeBatched/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/samples/jpegDecodeBatched/jpegdecodebatched.cpp
+++ b/samples/jpegDecodeBatched/jpegdecodebatched.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/samples/jpegDecodePerf/CMakeLists.txt
+++ b/samples/jpegDecodePerf/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/samples/jpegDecodePerf/jpegdecodeperf.cpp
+++ b/samples/jpegDecodePerf/jpegdecodeperf.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/samples/rocjpeg_samples_utils.h
+++ b/samples/rocjpeg_samples_utils.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
+++ b/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/amd_detail/rocjpeg_api_trace.cpp
+++ b/src/amd_detail/rocjpeg_api_trace.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_api.cpp
+++ b/src/rocjpeg_api.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_api_decoder_handle.h
+++ b/src/rocjpeg_api_decoder_handle.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_api_stream_handle.h
+++ b/src/rocjpeg_api_stream_handle.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_commons.h
+++ b/src/rocjpeg_commons.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_decoder.cpp
+++ b/src/rocjpeg_decoder.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_decoder.h
+++ b/src/rocjpeg_decoder.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_hip_kernels.cpp
+++ b/src/rocjpeg_hip_kernels.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_hip_kernels.h
+++ b/src/rocjpeg_hip_kernels.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_parser.cpp
+++ b/src/rocjpeg_parser.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_parser.h
+++ b/src/rocjpeg_parser.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_vaapi_decoder.cpp
+++ b/src/rocjpeg_vaapi_decoder.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/rocjpeg_vaapi_decoder.h
+++ b/src/rocjpeg_vaapi_decoder.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ##############################################################################
-# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/test/rocjpeg_negative_api_tests/CMakeLists.txt
+++ b/test/rocjpeg_negative_api_tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc.
+# Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/test/rocjpeg_negative_api_tests/rocjpeg_api_negative_tests.cpp
+++ b/test/rocjpeg_negative_api_tests/rocjpeg_api_negative_tests.cpp
@@ -1,6 +1,6 @@
 
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/test/rocjpeg_negative_api_tests/rocjpeg_api_negative_tests.h
+++ b/test/rocjpeg_negative_api_tests/rocjpeg_api_negative_tests.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/test/rocjpeg_negative_api_tests/rocjpegnegativetest.cpp
+++ b/test/rocjpeg_negative_api_tests/rocjpegnegativetest.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Motivation

Update the copyright year to 2026

## Technical Details

Update the copyright year to 2026

## Test Plan

rocjpeg ctest

## Test Result

rocjpeg ctest should pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
