### PR TITLE
Add asynchronous decode API

### DIFF
--- a/api/amd_detail/rocjpeg_api_trace.h
+++ b/api/amd_detail/rocjpeg_api_trace.h
@@ -45,7 +45,7 @@ THE SOFTWARE.
 
 // Increment the ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION when new runtime API functions are added.
 // If the corresponding ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION increases reset the ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION to zero.
-#define ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION 0
+#define ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION 1
 
 // rocJPEG API interface
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegStreamCreate)(RocJpegStreamHandle *jpeg_stream_handle);
@@ -55,6 +55,8 @@ typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegCreate)(RocJpegBackend backend, int
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDestroy)(RocJpegHandle handle);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegGetImageInfo)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, uint8_t *num_components, RocJpegChromaSubsampling *subsampling, uint32_t *widths, uint32_t *heights);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecode)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeAsync)(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegSyncSurface)(RocJpegHandle handle, RocJpegImage *destination);
 typedef RocJpegStatus (ROCJPEGAPI *PfnRocJpegDecodeBatched)(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 typedef const char* (ROCJPEGAPI *PfnRocJpegGetErrorName)(RocJpegStatus rocjpeg_status);
 
@@ -75,6 +77,11 @@ struct RocJpegDispatchTable {
 
     // PLEASE DO NOT EDIT ABOVE!
     // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 1
+    PfnRocJpegDecodeAsync pfn_rocjpeg_decode_async;
+    PfnRocJpegSyncSurface pfn_rocjpeg_sync_surface;
+
+    // PLEASE DO NOT EDIT ABOVE!
+    // ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 2
 
     // ******************************************************************************************* //
     //                                            READ BELOW

--- a/api/rocjpeg/rocjpeg.h
+++ b/api/rocjpeg/rocjpeg.h
@@ -313,6 +313,30 @@ RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStream
 
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
+/**
+ * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+ * @ingroup group_amd_rocjpeg
+ * @brief Submits a JPEG decode operation without waiting for the output.
+ *
+ * @param handle The rocJPEG handle.
+ * @param jpeg_stream_handle The rocJPEG stream handle.
+ * @param decode_params The decoding parameters.
+ * @param destination The output image.
+ * @return A RocJpegStatus indicating the success or failure of the submit operation.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+
+/**
+ * @fn RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
+ * @ingroup group_amd_rocjpeg
+ * @brief Synchronizes a pending asynchronous JPEG decode.
+ *
+ * @param handle The rocJPEG handle.
+ * @param destination A pointer to RocJpegImage where the decoded image will be stored.
+ * @return A RocJpegStatus indicating the success or failure of the sync operation.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
+
 
 /**
  * @fn RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);

--- a/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
+++ b/src/amd_detail/rocjpeg_api_dispatch_interface.cpp
@@ -47,6 +47,12 @@ RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStream
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
     return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode(handle, jpeg_stream_handle, decode_params, destination);
 }
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_async(handle, jpeg_stream_handle, decode_params, destination);
+}
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
+    return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_sync_surface(handle, destination);
+}
 RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations) {
     return rocjpeg::GetRocJpegDispatchTable()->pfn_rocjpeg_decode_batched(handle, jpeg_stream_handles, batch_size, decode_params, destinations);
 }

--- a/src/amd_detail/rocjpeg_api_trace.cpp
+++ b/src/amd_detail/rocjpeg_api_trace.cpp
@@ -41,6 +41,8 @@ RocJpegStatus ROCJPEGAPI rocJpegCreate(RocJpegBackend backend, int device_id, Ro
 RocJpegStatus ROCJPEGAPI rocJpegDestroy(RocJpegHandle handle);
 RocJpegStatus ROCJPEGAPI rocJpegGetImageInfo(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, uint8_t *num_components, RocJpegChromaSubsampling *subsampling, uint32_t *widths, uint32_t *heights);
 RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination);
 RocJpegStatus ROCJPEGAPI rocJpegDecodeBatched(RocJpegHandle handle, RocJpegStreamHandle *jpeg_stream_handles, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 const char* ROCJPEGAPI rocJpegGetErrorName(RocJpegStatus rocjpeg_status);
 }
@@ -58,6 +60,8 @@ void UpdateDispatchTable(RocJpegDispatchTable* ptr_dispatch_table) {
     ptr_dispatch_table->pfn_rocjpeg_decode = rocjpeg::rocJpegDecode;
     ptr_dispatch_table->pfn_rocjpeg_decode_batched = rocjpeg::rocJpegDecodeBatched;
     ptr_dispatch_table->pfn_rocjpeg_get_error_name = rocjpeg::rocJpegGetErrorName;
+    ptr_dispatch_table->pfn_rocjpeg_decode_async = rocjpeg::rocJpegDecodeAsync;
+    ptr_dispatch_table->pfn_rocjpeg_sync_surface = rocjpeg::rocJpegSyncSurface;
 }
 
 #if ROCJPEG_ROCPROFILER_REGISTER > 0
@@ -140,14 +144,16 @@ ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_get_image_info, 5)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode, 6)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_batched, 7)
 ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_get_error_name, 8)
+ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_decode_async, 9)
+ROCJPEG_ENFORCE_ABI(RocJpegDispatchTable, pfn_rocjpeg_sync_surface, 10)
 
 // If ROCJPEG_ENFORCE_ABI entries are added for each new function pointer in the table,
 // the number below will be one greater than the number in the last ROCJPEG_ENFORCE_ABI line. For example:
 //  ROCJPEG_ENFORCE_ABI(<table>, <functor>, 8)
-//  ROCJPEG_ENFORCE_ABI_VERSIONING(<table>, 9) <- 8 + 1 = 9
-ROCJPEG_ENFORCE_ABI_VERSIONING(RocJpegDispatchTable, 9)
+//  ROCJPEG_ENFORCE_ABI_VERSIONING(<table>, 11) <- 10 + 1 = 11
+ROCJPEG_ENFORCE_ABI_VERSIONING(RocJpegDispatchTable, 11)
 
-static_assert(ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 0,
+static_assert(ROCJPEG_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && ROCJPEG_RUNTIME_API_TABLE_STEP_VERSION == 1,
               "If you encounter this error, add the new ROCJPEG_ENFORCE_ABI(...) code for the updated function pointers, "
               "and then modify this check to ensure it evaluates to true.");
 #endif

--- a/src/rocjpeg_api.cpp
+++ b/src/rocjpeg_api.cpp
@@ -210,6 +210,50 @@ RocJpegStatus ROCJPEGAPI rocJpegDecode(RocJpegHandle handle, RocJpegStreamHandle
 }
 
 /**
+ * @brief Submits a JPEG decode operation without waiting for output completion.
+ *
+ * rocJpegSyncSurface must be called with the same rocJPEG handle to wait for completion, write the image,
+ * release internal resources, and clear the pending asynchronous decode state.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegDecodeAsync(RocJpegHandle handle, RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+
+    if (handle == nullptr || jpeg_stream_handle == nullptr || decode_params == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
+    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
+    try {
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->DecodeAsync(jpeg_stream_handle, decode_params, destination);
+    } catch (const std::exception& e) {
+        rocjpeg_handle->CaptureError(e.what());
+        ERR(e.what());
+        return ROCJPEG_STATUS_RUNTIME_ERROR;
+    }
+
+    return rocjpeg_status;
+}
+
+/**
+ * @brief Synchronizes an asynchronous JPEG decode surface and writes the decoded output.
+ */
+RocJpegStatus ROCJPEGAPI rocJpegSyncSurface(RocJpegHandle handle, RocJpegImage *destination) {
+    if (handle == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    RocJpegStatus rocjpeg_status = ROCJPEG_STATUS_SUCCESS;
+    auto rocjpeg_handle = static_cast<RocJpegDecoderHandle*>(handle);
+    try {
+        rocjpeg_status = rocjpeg_handle->rocjpeg_decoder->SyncSurface(destination);
+    } catch (const std::exception& e) {
+        rocjpeg_handle->CaptureError(e.what());
+        ERR(e.what());
+        return ROCJPEG_STATUS_RUNTIME_ERROR;
+    }
+
+    return rocjpeg_status;
+}
+
+/**
  * @brief Decodes a batch of JPEG images using the rocJPEG library.
  *
  * Decodes a batch of JPEG images using the specified handle, stream handles, decode parameters, and destination images.

--- a/src/rocjpeg_decoder.cpp
+++ b/src/rocjpeg_decoder.cpp
@@ -26,6 +26,14 @@ RocJpegDecoder::RocJpegDecoder(RocJpegBackend backend, int device_id) :
     num_devices_{0}, device_id_ {device_id}, hip_stream_ {0}, backend_{backend} {}
 
 RocJpegDecoder::~RocJpegDecoder() {
+    if (async_decode_state_) {
+        RocJpegStatus rocjpeg_status = jpeg_vaapi_decoder_.SyncSurface(async_decode_state_->surface_id);
+        if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+            ERR("ERROR: failed to sync pending async surface during destroy!");
+        }
+        jpeg_vaapi_decoder_.SetSurfaceAsIdle(async_decode_state_->surface_id);
+        async_decode_state_.reset();
+    }
     if (hip_stream_) {
         hipError_t hip_status = hipStreamDestroy(hip_stream_);
         if (hip_status != hipSuccess) {
@@ -111,11 +119,86 @@ RocJpegStatus RocJpegDecoder::Decode(RocJpegStreamHandle jpeg_stream_handle, con
     if (jpeg_stream_handle == nullptr || decode_params == nullptr || destination == nullptr) {
         return ROCJPEG_STATUS_INVALID_PARAMETER;
     }
+    if (async_decode_state_) {
+        ERR("ERROR: an asynchronous decode is already pending for this handle!");
+        return ROCJPEG_STATUS_EXECUTION_FAILED;
+    }
     auto rocjpeg_stream_handle = static_cast<RocJpegStreamParserHandle*>(jpeg_stream_handle);
     const JpegStreamParameters *jpeg_stream_params = rocjpeg_stream_handle->rocjpeg_stream->GetJpegStreamParameters();
 
     VASurfaceID current_surface_id;
     CHECK_ROCJPEG(jpeg_vaapi_decoder_.SubmitDecode(jpeg_stream_params, current_surface_id, decode_params));
+
+    RocJpegStatus rocjpeg_status = SyncDecodeSurface(current_surface_id, jpeg_stream_params, decode_params, destination);
+    if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+        jpeg_vaapi_decoder_.SetSurfaceAsIdle(current_surface_id);
+    }
+    return rocjpeg_status;
+}
+
+/**
+ * @brief Submits a JPEG decode operation and returns immediately with pending state stored in this decoder handle.
+ *
+ * The decoder handle owns the submitted VA surface until SyncSurface is called. SyncSurface waits for the
+ * surface, copies/converts the decoded output, releases the surface back to the pool, and clears the pending state.
+ */
+RocJpegStatus RocJpegDecoder::DecodeAsync(RocJpegStreamHandle jpeg_stream_handle, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (jpeg_stream_handle == nullptr || decode_params == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    if (async_decode_state_) {
+        ERR("ERROR: an asynchronous decode is already pending for this handle!");
+        return ROCJPEG_STATUS_EXECUTION_FAILED;
+    }
+
+    auto rocjpeg_stream_handle = static_cast<RocJpegStreamParserHandle*>(jpeg_stream_handle);
+    const JpegStreamParameters *jpeg_stream_params = rocjpeg_stream_handle->rocjpeg_stream->GetJpegStreamParameters();
+
+    async_decode_state_.reset(new AsyncDecodeState());
+    async_decode_state_->jpeg_stream_params = *jpeg_stream_params;
+    async_decode_state_->decode_params = *decode_params;
+    async_decode_state_->destination = destination;
+
+    RocJpegStatus rocjpeg_status = jpeg_vaapi_decoder_.SubmitDecode(&async_decode_state_->jpeg_stream_params, async_decode_state_->surface_id, &async_decode_state_->decode_params);
+    if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+        async_decode_state_.reset();
+        return rocjpeg_status;
+    }
+
+    return ROCJPEG_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Synchronizes an asynchronous decode surface and copies/converts the decoded output.
+ */
+RocJpegStatus RocJpegDecoder::SyncSurface(RocJpegImage *destination) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!async_decode_state_) {
+        ERR("ERROR: no asynchronous decode is pending for this handle!");
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    if (destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+
+    RocJpegStatus rocjpeg_status = SyncDecodeSurface(async_decode_state_->surface_id, &async_decode_state_->jpeg_stream_params, &async_decode_state_->decode_params, destination);
+    if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
+        jpeg_vaapi_decoder_.SetSurfaceAsIdle(async_decode_state_->surface_id);
+        async_decode_state_.reset();
+        return rocjpeg_status;
+    }
+    async_decode_state_.reset();
+    return ROCJPEG_STATUS_SUCCESS;
+}
+
+/**
+ * @brief Waits for a submitted VA surface, maps it through HIP interop, and writes the requested output.
+ */
+RocJpegStatus RocJpegDecoder::SyncDecodeSurface(VASurfaceID current_surface_id, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destination) {
+    if (jpeg_stream_params == nullptr || decode_params == nullptr || destination == nullptr) {
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
 
     HipInteropDeviceMem hip_interop_dev_mem = {};
     CHECK_ROCJPEG(jpeg_vaapi_decoder_.SyncSurface(current_surface_id));
@@ -201,6 +284,10 @@ RocJpegStatus RocJpegDecoder::DecodeBatched(RocJpegStreamHandle *jpeg_streams, i
     std::lock_guard<std::mutex> lock(mutex_);
     if (jpeg_streams == nullptr || decode_params == nullptr || destinations == nullptr) {
         return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    if (async_decode_state_) {
+        ERR("ERROR: an asynchronous decode is already pending for this handle!");
+        return ROCJPEG_STATUS_EXECUTION_FAILED;
     }
 
     std::vector<VASurfaceID> current_surface_ids;

--- a/src/rocjpeg_decoder.h
+++ b/src/rocjpeg_decoder.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include <vector>
 #include <mutex>
 #include <queue>
+#include <memory>
 #include "../api/rocjpeg/rocjpeg.h"
 #include "rocjpeg_api_stream_handle.h"
 #include "rocjpeg_parser.h"
@@ -84,6 +85,22 @@ public:
     */
    RocJpegStatus Decode(RocJpegStreamHandle jpeg_stream, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
+    /**
+      * @brief Submits a JPEG decode operation and stores pending state in this decoder handle.
+      * @param jpeg_stream The handle to the JPEG stream.
+      * @param decode_params The decoding parameters.
+         * @param destination Pointer to the output image.
+      * @return The status of the submit operation.
+      */
+      RocJpegStatus DecodeAsync(RocJpegStreamHandle jpeg_stream, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
+
+   /**
+    * @brief Synchronizes an asynchronous decode surface and copies/converts the output.
+   * @param destination Pointer to the destination image.
+    * @return The status of the sync operation.
+    */
+   RocJpegStatus SyncSurface(RocJpegImage *destination);
+
    /**
     * Decodes a batch of JPEG streams.
     *
@@ -100,12 +117,24 @@ public:
    RocJpegStatus DecodeBatched(RocJpegStreamHandle *jpeg_streams, int batch_size, const RocJpegDecodeParams *decode_params, RocJpegImage *destinations);
 
 private:
+   struct AsyncDecodeState {
+      VASurfaceID surface_id;
+      JpegStreamParameters jpeg_stream_params;
+      RocJpegDecodeParams decode_params;
+      RocJpegImage *destination;
+   };
+
    /**
     * @brief Initializes the HIP framework.
     * @param device_id The ID of the device to be used for HIP operations.
     * @return The status of the initialization process.
     */
    RocJpegStatus InitHIP(int device_id);
+
+   /**
+    * @brief Waits for a submitted surface and copies/converts the decoded output.
+    */
+   RocJpegStatus SyncDecodeSurface(VASurfaceID surface_id, const JpegStreamParameters *jpeg_stream_params, const RocJpegDecodeParams *decode_params, RocJpegImage *destination);
 
    /**
     * @brief Retrieves the height of the chroma channel.
@@ -175,6 +204,7 @@ private:
    std::mutex mutex_; // Mutex for thread safety
    RocJpegBackend backend_; // RocJpeg backend
    RocJpegVappiDecoder jpeg_vaapi_decoder_; // RocJpeg VAAPI decoder object
+   std::unique_ptr<AsyncDecodeState> async_decode_state_; // Pending asynchronous decode state
 };
 
 #endif //ROC_JPEG_DECODER_H_


### PR DESCRIPTION
For some free run case,  vcn can't be used 100% due to decode/surface share get serialized, so add asynchronouse API to fully use VCN.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
